### PR TITLE
update typespecs and docs for Sensor.register

### DIFF
--- a/lib/scenic_sensor.ex
+++ b/lib/scenic_sensor.ex
@@ -244,7 +244,7 @@ defmodule Scenic.Sensor do
 
   ## Return Value
 
-  On success, returns `:ok`
+  On success, returns `{:ok, sensor_id}`
 
   If `sensor_id` is already registered to another process, it returns
 
@@ -254,7 +254,7 @@ defmodule Scenic.Sensor do
           sensor_id :: atom,
           version :: String.t(),
           description :: String.t()
-        ) :: :ok
+        ) :: {:ok, atom} | {:error, :already_registered}
   def register(sensor_id, version, description)
       when is_atom(sensor_id) and is_bitstring(version) and is_bitstring(description) do
     GenServer.call(


### PR DESCRIPTION
While working on https://github.com/mmmries/scenic_fuel_gauge/pull/2 I noticed that the documentation for `Sensor.register` was wrong. When I called that function during my scene setup I actually got back `{:ok, :battery_level}` instead of just `:ok`.

This PR just updates the documentation and typespecs. It also includes the error case in the typespec. It seems like most libraries include the error case in their typespecs from what I've seen, but I'm fine with leaving that out if you don't want to document the type that way